### PR TITLE
food for discussion: NSCloudKitPersistentContainer adoption

### DIFF
--- a/Sources/MigrationDelegate.swift
+++ b/Sources/MigrationDelegate.swift
@@ -49,7 +49,7 @@ public protocol MigrationDelegate: class {
     /// - Parameters:
     ///   - container: The `PersistentContainer` asked to load the store.
     ///   - willConsiderStore: The store that may be migrated.
-    func persistentContainer(_ container: PersistentContainer,
+    func persistentContainer(_ container: NSPersistentContainer,
                              willConsiderStore: NSPersistentStoreDescription)
 
     /// Called for each store that will be migrated, before any migrations start for the store.
@@ -60,7 +60,7 @@ public protocol MigrationDelegate: class {
     ///   - sourceModelVersion: The model version that the store currently has.
     ///   - destinationModelVersion: The model version that the store will have after all migrations.
     ///   - totalSteps: The number of separate migration steps that will be executed on the store.
-    func persistentContainer(_ container: PersistentContainer,
+    func persistentContainer(_ container: NSPersistentContainer,
                              willMigrateStore: NSPersistentStoreDescription,
                              sourceModelVersion: String,
                              destinationModelVersion: String,
@@ -73,7 +73,7 @@ public protocol MigrationDelegate: class {
     ///   - container: The `PersistentContainer` asked to load the store.
     ///   - willNotMigrateStore: The store that will not be migrated.
     ///   - storeExists: `true` if the store exists on disk at the right version.
-    func persistentContainer(_ container: PersistentContainer,
+    func persistentContainer(_ container: NSPersistentContainer,
                              willNotMigrateStore: NSPersistentStoreDescription,
                              storeExists: Bool)
 
@@ -89,7 +89,7 @@ public protocol MigrationDelegate: class {
     ///   - toTemporaryLocation: The location on disk of the migrated version of the store.
     ///   - stepsRemaining: The number of migration steps remaining for the store, **including** this step!
     ///   - totalSteps: The total number of migration steps for this store.
-    func persistentContainer(_ container: PersistentContainer,
+    func persistentContainer(_ container: NSPersistentContainer,
                              willSingleMigrateStore: NSPersistentStoreDescription,
                              sourceModelVersion: String,
                              destinationModelVersion: String,
@@ -104,7 +104,7 @@ public protocol MigrationDelegate: class {
     /// - Parameters:
     ///   - container: The `PersistentContainer` asked to load the store.
     ///   - didMigrateStore: The store that has been migrated.
-    func persistentContainer(_ container: PersistentContainer,
+    func persistentContainer(_ container: NSPersistentContainer,
                              didMigrateStore: NSPersistentStoreDescription)
 
     /// Called after an error has occurred during or before migrating a store.
@@ -114,7 +114,7 @@ public protocol MigrationDelegate: class {
     ///   - container: The `PersistentContainer` asked to load the store.
     ///   - didFailToMigrateStore: The store that could not be migrated.
     ///   - error: The reason the store could not be migrated, could be from `MigrationError`.
-    func persistentContainer(_ container: PersistentContainer,
+    func persistentContainer(_ container: NSPersistentContainer,
                              didFailToMigrateStore: NSPersistentStoreDescription,
                              error: Error)
 }
@@ -123,12 +123,12 @@ public protocol MigrationDelegate: class {
 @available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
 public extension MigrationDelegate {
     /// Do nothing.
-    func persistentContainer(_ container: PersistentContainer,
+    func persistentContainer(_ container: NSPersistentContainer,
                              willConsiderStore: NSPersistentStoreDescription) {
     }
 
     /// Do nothing.
-    func persistentContainer(_ container: PersistentContainer,
+    func persistentContainer(_ container: NSPersistentContainer,
                              willMigrateStore: NSPersistentStoreDescription,
                              sourceModelVersion: String,
                              destinationModelVersion: String,
@@ -136,13 +136,13 @@ public extension MigrationDelegate {
     }
 
     /// Do nothing.
-    func persistentContainer(_ container: PersistentContainer,
+    func persistentContainer(_ container: NSPersistentContainer,
                              willNotMigrateStore: NSPersistentStoreDescription,
                              storeExists: Bool) {
     }
 
     /// Do nothing.
-    func persistentContainer(_ container: PersistentContainer,
+    func persistentContainer(_ container: NSPersistentContainer,
                              willSingleMigrateStore: NSPersistentStoreDescription,
                              sourceModelVersion: String,
                              destinationModelVersion: String,
@@ -154,12 +154,12 @@ public extension MigrationDelegate {
     }
 
     /// Do nothing.
-    func persistentContainer(_ container: PersistentContainer,
+    func persistentContainer(_ container: NSPersistentContainer,
                              didMigrateStore: NSPersistentStoreDescription) {
     }
 
     /// Do nothing.
-    func persistentContainer(_ container: PersistentContainer,
+    func persistentContainer(_ container: NSPersistentContainer,
                              didFailToMigrateStore: NSPersistentStoreDescription,
                              error: Error) {
     }

--- a/Sources/PersistentCloudKitContainer.swift
+++ b/Sources/PersistentCloudKitContainer.swift
@@ -110,4 +110,35 @@ open class PersistentCloudKitContainer: NSPersistentCloudKitContainer, Persisten
         self.logMessageHandler = logMessageHandler
         super.init(name: name, managedObjectModel: model)
     }
+    
+    /// Begin loading and migrating the persistent stores mentioned in `persistentStoreDescriptions` that have
+    /// not already been loaded. The completion handler is called once for each such store on the main queue
+    /// indicating whether the store has been loaded successfully.
+    ///
+    /// If the store description has `shouldMigrateStoreAutomatically` set then the container automatically
+    /// attempts multi-step migration.  If the store description also has `shouldInferMappingModelAutomatically`
+    /// set then the multi-step migration can include the use of inferred mapping models and light-weight
+    /// migration.  Once any multi-step migration is complete, Core Data is invoked to load the store and set
+    /// up the stack for use.
+    ///
+    /// These flags are both on by default.
+    ///
+    /// If *any* of the store descriptions have `shouldAddStoreAsynchronously` set then this routine returns
+    /// immediately and *all* migrations occur on a background queue.  This flag is off by default.
+    ///
+    /// If the container has multiple stores then the container tries very hard to ensure either all stores
+    /// are migrated successfully or none are.
+    ///
+    /// - Parameter block: Callback made on the main queue for each store when it has either been loaded successfully
+    ///                    or failed to load.  The `Error` here can be anything provided by
+    ///                    `NSPersistentContainer.loadPersistentStores` as well as anything from `MigrationError`
+    ///                    in this package.
+    ///
+    open override func loadPersistentStores(completionHandler block: @escaping (NSPersistentStoreDescription, Error?) -> ()) {
+        let invokeCoreDataClosure = { block in
+            super.loadPersistentStores(completionHandler: block)
+        }
+        
+        loadPersistentStoresHelper(invokeCoreDataClosure: invokeCoreDataClosure, completionHandler: block)
+    }
 }

--- a/Sources/PersistentCloudKitContainer.swift
+++ b/Sources/PersistentCloudKitContainer.swift
@@ -18,7 +18,7 @@ import CoreData
 open class PersistentCloudKitContainer: NSPersistentCloudKitContainer, PersistentContainerMigratable, PersistentContainerProtocol, LogMessageEmitter {
 
     /// Background queue for running store operations.
-    private let dispatchQueue = DispatchQueue(label: "PersistentContainer", qos: .utility)
+    private let dispatchQueue = DispatchQueue(label: "CloudKitPersistentContainer", qos: .utility)
 
     /// User's model version order.
     let modelVersionOrder: ModelVersionOrder

--- a/Sources/PersistentCloudKitContainer.swift
+++ b/Sources/PersistentCloudKitContainer.swift
@@ -1,10 +1,3 @@
-//
-//  PersistentContainer.swift
-//  TMLPersistentContainer
-//
-//  Distributed under the ISC license, see LICENSE.
-//
-
 import Foundation
 import CoreData
 
@@ -21,8 +14,8 @@ import CoreData
 ///
 /// See [the user guide](https://johnfairh.github.io/TMLPersistentContainer/usage.html) for more details.
 ///
-@available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
-open class PersistentContainer: NSPersistentContainer, PersistentContainerMigratable, LogMessageEmitter {
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+open class PersistentCloudKitContainer: NSPersistentCloudKitContainer, PersistentContainerMigratable, LogMessageEmitter {
 
     /// Background queue for running store operations.
     private let dispatchQueue = DispatchQueue(label: "PersistentContainer", qos: .utility)

--- a/Sources/PersistentCloudKitContainer.swift
+++ b/Sources/PersistentCloudKitContainer.swift
@@ -15,7 +15,7 @@ import CoreData
 /// See [the user guide](https://johnfairh.github.io/TMLPersistentContainer/usage.html) for more details.
 ///
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
-open class PersistentCloudKitContainer: NSPersistentCloudKitContainer, PersistentContainerMigratable, LogMessageEmitter {
+open class PersistentCloudKitContainer: NSPersistentCloudKitContainer, PersistentContainerMigratable, PersistentContainerProtocol, LogMessageEmitter {
 
     /// Background queue for running store operations.
     private let dispatchQueue = DispatchQueue(label: "PersistentContainer", qos: .utility)
@@ -118,30 +118,6 @@ open class PersistentCloudKitContainer: NSPersistentCloudKitContainer, Persisten
         self.modelVersionOrder = modelVersionOrder
         self.logMessageHandler = logMessageHandler
         super.init(name: name, managedObjectModel: model)
-    }
-
-    /// Cleanly empty all the persistent stores described by `persistentStoreDescriptions`.
-    /// Typically useful to reset the app to a fresh state before loading the stores.
-    ///
-    /// - Attention: May not remove files from disk. In the case of SQLite3 stores, database files
-    ///              making up an empty store are left.
-    ///
-    /// - Attention: Goodness knows what this will do with custom stores. There does not appear to be
-    ///              an API into the `NSPersistentStore` tree to implement this operation.
-    ///
-    /// - Attention: Not atomic with respect to multiple stores. The routine attempts to destroy
-    ///              each store one by one; the first destroy operation to fail causes the entire
-    ///              routine to fail.
-    ///
-    /// - Throws: Errors thrown by `NSPersistentStoreCoordinator.destroyPersistentStore(at:ofType:options:)` which
-    ///           is undocumented: assumed to be filesystem access errors that the app should probably consider as
-    ///           fatal. Does *not* throw an error if a persistent store does not currently exist.
-    ///
-    open func destroyStores() throws {
-        try persistentStoreDescriptions.forEach { description in
-            log(.info, "Destroying store \(description)")
-            try description.destroyStore(coordinator: self.persistentStoreCoordinator)
-        }
     }
 
     /// Begin loading and migrating the persistent stores mentioned in `persistentStoreDescriptions` that have

--- a/Sources/PersistentContainer+Migration.swift
+++ b/Sources/PersistentContainer+Migration.swift
@@ -16,6 +16,31 @@ struct MigratedStore
     let tempURL: URL
 }
 
+protocol PersistentContainerMigratable: class, LogMessageEmitter {
+    
+    /// User's model version order.
+    var modelVersionOrder: ModelVersionOrder { get }
+
+    /// List of bundles to search for Core Data models.
+    var bundles: [Bundle] { get }
+    
+    var migrationDelegate: MigrationDelegate? { get }
+    
+    /// Core Data model version graph discovered from the bundles.
+    var modelVersionGraph: ModelVersionGraph? { get set }
+    
+    /// Migrate all the stores as necessary.  Must call `errorCallback` for all or none of the stores.
+    func migrateStores(descriptions: [NSPersistentStoreDescription],
+                       errorCallback: (NSPersistentStoreDescription,Error) -> Void)
+    
+    /// Migration of a single store.  Attempt to migrate the store described by 'description' that
+    /// currently has metadata 'storeMetadata' up to a model version compatible with the
+    /// 'managedObjectModel' property of the container.
+    func migrateStore(description: NSPersistentStoreDescription,
+                      storeMetadata: PersistentStoreMetadata,
+                      tempDirectory: TemporaryDirectory) throws -> MigratedStore
+}
+
 /// This file contains the top-level store migration code.
 ///
 /// It's fairly painful to read given the number of objects that have
@@ -49,7 +74,7 @@ struct MigratedStore
 /// store marked with a filesystem error from `replacePersistentStore`.  When the user fixes their
 /// filesystem and retries this, everything should be fine.
 @available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
-extension PersistentContainer {
+extension PersistentContainerMigratable where Self: NSPersistentContainer {
 
     /// Migrate all the stores as necessary.  Must call `errorCallback` for all or none of the stores.
     func migrateStores(descriptions: [NSPersistentStoreDescription],

--- a/Sources/PersistentContainer+Migration.swift
+++ b/Sources/PersistentContainer+Migration.swift
@@ -16,6 +16,7 @@ struct MigratedStore
     let tempURL: URL
 }
 
+@available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
 protocol PersistentContainerMigratable: NSPersistentContainer, LogMessageEmitter {
     
     /// User's model version order.

--- a/Sources/PersistentContainer+Migration.swift
+++ b/Sources/PersistentContainer+Migration.swift
@@ -16,7 +16,7 @@ struct MigratedStore
     let tempURL: URL
 }
 
-protocol PersistentContainerMigratable: class, LogMessageEmitter {
+protocol PersistentContainerMigratable: NSPersistentContainer, LogMessageEmitter {
     
     /// User's model version order.
     var modelVersionOrder: ModelVersionOrder { get }
@@ -74,7 +74,7 @@ protocol PersistentContainerMigratable: class, LogMessageEmitter {
 /// store marked with a filesystem error from `replacePersistentStore`.  When the user fixes their
 /// filesystem and retries this, everything should be fine.
 @available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
-extension PersistentContainerMigratable where Self: NSPersistentContainer {
+extension PersistentContainerMigratable {
 
     /// Migrate all the stores as necessary.  Must call `errorCallback` for all or none of the stores.
     func migrateStores(descriptions: [NSPersistentStoreDescription],

--- a/Sources/PersistentContainer.swift
+++ b/Sources/PersistentContainer.swift
@@ -13,6 +13,7 @@ protocol PersistentContainerProtocol: PersistentContainerMigratable {
     func destroyStores() throws
 }
 
+@available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
 extension PersistentContainerProtocol {
     /// Cleanly empty all the persistent stores described by `persistentStoreDescriptions`.
     /// Typically useful to reset the app to a fresh state before loading the stores.

--- a/Sources/PersistentContainer.swift
+++ b/Sources/PersistentContainer.swift
@@ -8,6 +8,7 @@
 import Foundation
 import CoreData
 
+@available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
 protocol PersistentContainerProtocol: PersistentContainerMigratable {
     func destroyStores() throws
 }

--- a/Sources/PersistentContainer.swift
+++ b/Sources/PersistentContainer.swift
@@ -188,27 +188,19 @@ open class PersistentContainer: NSPersistentContainer, PersistentContainerMigrat
         // can't see how to avoid.  No self so logging ugly too :(
         //
         // Investigation does show that NSPC.init(string) searches for .momds and NOT .moms.
-        for bundle in bundles {
-            if let url = bundle.url(forResource: name, withExtension: "momd") {
-                if let model = NSManagedObjectModel(contentsOf: url) {
-                    logMessageHandler?(LogMessage(.info, "Using \(url) for model \(name)."))
-                    self.init(name: name,
-                              managedObjectModel: model,
-                              bundles: bundles,
-                              modelVersionOrder: modelVersionOrder,
-                              logMessageHandler: logMessageHandler)
-                    return                                    /* EXIT FUNCTION */
-                } else {
-                    logMessageHandler?(LogMessage(.warning, "Found \(url) but cannot load it as NSManagedObjectModel."))
-                }
-            }
+        
+        let firstModelFromBundles = bundles.managedObjectModels(with: name).first
+        
+        if firstModelFromBundles == nil {
+            logMessageHandler?(LogMessage(.error, "Found no models matching \(name), using empty NSManagedObjectModel."))
+        } else {
+            logMessageHandler?(LogMessage(.info, "Using \(firstModelFromBundles.debugDescription) for model \(name)."))
         }
-
-        // well...
-        logMessageHandler?(LogMessage(.error, "Found no models matching \(name), using empty NSManagedObjectModel."))
-
+        
+        let model = firstModelFromBundles ?? NSManagedObjectModel()
+        
         self.init(name: name,
-                  managedObjectModel: NSManagedObjectModel(),
+                  managedObjectModel: model,
                   bundles: bundles,
                   modelVersionOrder: modelVersionOrder,
                   logMessageHandler: logMessageHandler)

--- a/Sources/PersistentContainer.swift
+++ b/Sources/PersistentContainer.swift
@@ -184,8 +184,7 @@ open class PersistentContainer: NSPersistentContainer, PersistentContainerMigrat
                             modelVersionOrder: ModelVersionOrder = .compare,
                             logMessageHandler: LogMessage.Handler? = nil) {
 
-        // This is all pretty messy, don't want to be doing this stuff in initializer but
-        // can't see how to avoid.  No self so logging ugly too :(
+        // No self so logging is ugly :(
         //
         // Investigation does show that NSPC.init(string) searches for .momds and NOT .moms.
         

--- a/Sources/PersistentContainer.swift
+++ b/Sources/PersistentContainer.swift
@@ -8,6 +8,36 @@
 import Foundation
 import CoreData
 
+protocol PersistentContainerProtocol: PersistentContainerMigratable {
+    func destroyStores() throws
+}
+
+extension PersistentContainerProtocol {
+    /// Cleanly empty all the persistent stores described by `persistentStoreDescriptions`.
+    /// Typically useful to reset the app to a fresh state before loading the stores.
+    ///
+    /// - Attention: May not remove files from disk. In the case of SQLite3 stores, database files
+    ///              making up an empty store are left.
+    ///
+    /// - Attention: Goodness knows what this will do with custom stores. There does not appear to be
+    ///              an API into the `NSPersistentStore` tree to implement this operation.
+    ///
+    /// - Attention: Not atomic with respect to multiple stores. The routine attempts to destroy
+    ///              each store one by one; the first destroy operation to fail causes the entire
+    ///              routine to fail.
+    ///
+    /// - Throws: Errors thrown by `NSPersistentStoreCoordinator.destroyPersistentStore(at:ofType:options:)` which
+    ///           is undocumented: assumed to be filesystem access errors that the app should probably consider as
+    ///           fatal. Does *not* throw an error if a persistent store does not currently exist.
+    ///
+    public func destroyStores() throws {
+        try persistentStoreDescriptions.forEach { description in
+            log(.info, "Destroying store \(description)")
+            try description.destroyStore(coordinator: self.persistentStoreCoordinator)
+        }
+    }
+}
+
 /// A container for a Core Data stack that provides automatic multi-step shortest-path
 /// persistent store migration.
 ///
@@ -22,7 +52,7 @@ import CoreData
 /// See [the user guide](https://johnfairh.github.io/TMLPersistentContainer/usage.html) for more details.
 ///
 @available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
-open class PersistentContainer: NSPersistentContainer, PersistentContainerMigratable, LogMessageEmitter {
+open class PersistentContainer: NSPersistentContainer, PersistentContainerMigratable, PersistentContainerProtocol, LogMessageEmitter {
 
     /// Background queue for running store operations.
     private let dispatchQueue = DispatchQueue(label: "PersistentContainer", qos: .utility)
@@ -125,30 +155,6 @@ open class PersistentContainer: NSPersistentContainer, PersistentContainerMigrat
         self.modelVersionOrder = modelVersionOrder
         self.logMessageHandler = logMessageHandler
         super.init(name: name, managedObjectModel: model)
-    }
-
-    /// Cleanly empty all the persistent stores described by `persistentStoreDescriptions`.
-    /// Typically useful to reset the app to a fresh state before loading the stores.
-    ///
-    /// - Attention: May not remove files from disk. In the case of SQLite3 stores, database files
-    ///              making up an empty store are left.
-    ///
-    /// - Attention: Goodness knows what this will do with custom stores. There does not appear to be
-    ///              an API into the `NSPersistentStore` tree to implement this operation.
-    ///
-    /// - Attention: Not atomic with respect to multiple stores. The routine attempts to destroy
-    ///              each store one by one; the first destroy operation to fail causes the entire
-    ///              routine to fail.
-    ///
-    /// - Throws: Errors thrown by `NSPersistentStoreCoordinator.destroyPersistentStore(at:ofType:options:)` which
-    ///           is undocumented: assumed to be filesystem access errors that the app should probably consider as
-    ///           fatal. Does *not* throw an error if a persistent store does not currently exist.
-    ///
-    open func destroyStores() throws {
-        try persistentStoreDescriptions.forEach { description in
-            log(.info, "Destroying store \(description)")
-            try description.destroyStore(coordinator: self.persistentStoreCoordinator)
-        }
     }
 
     /// Begin loading and migrating the persistent stores mentioned in `persistentStoreDescriptions` that have

--- a/Sources/Sequence+Extension.swift
+++ b/Sources/Sequence+Extension.swift
@@ -8,6 +8,13 @@
 import Foundation
 import CoreData
 
+// this allows mocking Bundle for the tests
+protocol BundleProtocol {
+    func url(forResource name: String?, withExtension ext: String?) -> URL?
+}
+
+extension Bundle: BundleProtocol {}
+
 extension Sequence where Iterator.Element == Bundle {
     
     /// this looks through all bundles of the sequence and returns all `NSManagedObjectModel` with the supplied `name`

--- a/Sources/Sequence+Extension.swift
+++ b/Sources/Sequence+Extension.swift
@@ -1,0 +1,24 @@
+//
+//  File.swift
+//  
+//
+//  Created by Jonas Reichert on 25.01.20.
+//
+
+import Foundation
+import CoreData
+
+extension Sequence where Iterator.Element == Bundle {
+    
+    /// this looks through all bundles of the sequence and returns all `NSManagedObjectModel` with the supplied `name`
+    /// - Parameters:
+    ///   - name: The name of the managed object model to use with the container.
+    ///           This name is used as the default name for the first persistent store.
+    func managedObjectModels(with name: String) -> [NSManagedObjectModel] {
+        return self.compactMap { (bundle) -> URL? in
+            bundle.url(forResource: name, withExtension: "momd")
+        }.compactMap { (url) -> NSManagedObjectModel? in
+            NSManagedObjectModel(contentsOf: url)
+        }
+    }
+}

--- a/Sources/Sequence+Extension.swift
+++ b/Sources/Sequence+Extension.swift
@@ -15,7 +15,7 @@ protocol BundleProtocol {
 
 extension Bundle: BundleProtocol {}
 
-extension Sequence where Iterator.Element == Bundle {
+extension Sequence where Iterator.Element: BundleProtocol {
     
     /// this looks through all bundles of the sequence and returns all `NSManagedObjectModel` with the supplied `name`
     /// - Parameters:

--- a/TMLPersistentContainer.xcodeproj/project.pbxproj
+++ b/TMLPersistentContainer.xcodeproj/project.pbxproj
@@ -137,6 +137,14 @@
 		52D6D9871BEFF229002C0205 /* TMLPersistentContainer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52D6D97C1BEFF229002C0205 /* TMLPersistentContainer.framework */; };
 		DD7502881C68FEDE006590AF /* TMLPersistentContainer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52D6DA0F1BF000BD002C0205 /* TMLPersistentContainer.framework */; };
 		DD7502921C690C7A006590AF /* TMLPersistentContainer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52D6D9F01BEFFFBE002C0205 /* TMLPersistentContainer.framework */; };
+		DD75716423DD7DBE00E825EC /* PersistentCloudKitContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD75716223DD7DBE00E825EC /* PersistentCloudKitContainer.swift */; };
+		DD75716523DD7DBE00E825EC /* PersistentCloudKitContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD75716223DD7DBE00E825EC /* PersistentCloudKitContainer.swift */; };
+		DD75716623DD7DBE00E825EC /* PersistentCloudKitContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD75716223DD7DBE00E825EC /* PersistentCloudKitContainer.swift */; };
+		DD75716723DD7DBE00E825EC /* PersistentCloudKitContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD75716223DD7DBE00E825EC /* PersistentCloudKitContainer.swift */; };
+		DD75716823DD7DBE00E825EC /* Sequence+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD75716323DD7DBE00E825EC /* Sequence+Extension.swift */; };
+		DD75716923DD7DBE00E825EC /* Sequence+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD75716323DD7DBE00E825EC /* Sequence+Extension.swift */; };
+		DD75716A23DD7DBE00E825EC /* Sequence+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD75716323DD7DBE00E825EC /* Sequence+Extension.swift */; };
+		DD75716B23DD7DBE00E825EC /* Sequence+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD75716323DD7DBE00E825EC /* Sequence+Extension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -234,6 +242,8 @@
 		AD2FAA281CD0B6E100659CF4 /* TMLPersistentContainerTests.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = TMLPersistentContainerTests.plist; sourceTree = "<group>"; };
 		DD75027A1C68FCFC006590AF /* TMLPersistentContainer-macOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "TMLPersistentContainer-macOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD75028D1C690C7A006590AF /* TMLPersistentContainer-tvOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "TMLPersistentContainer-tvOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		DD75716223DD7DBE00E825EC /* PersistentCloudKitContainer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PersistentCloudKitContainer.swift; path = Sources/PersistentCloudKitContainer.swift; sourceTree = "<group>"; };
+		DD75716323DD7DBE00E825EC /* Sequence+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Sequence+Extension.swift"; path = "Sources/Sequence+Extension.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -303,6 +313,8 @@
 		02FE15321E80382700FF077C /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				DD75716223DD7DBE00E825EC /* PersistentCloudKitContainer.swift */,
+				DD75716323DD7DBE00E825EC /* Sequence+Extension.swift */,
 				02FE15341E80384A00FF077C /* PersistentContainer.swift */,
 				02FE15331E80384A00FF077C /* PersistentContainer+Migration.swift */,
 				02FE15351E80384A00FF077C /* NSPersistentStoreDescription+Metadata.swift */,
@@ -746,8 +758,10 @@
 				02FE154A1E80384A00FF077C /* Graph.swift in Sources */,
 				02FE15411E80384A00FF077C /* NSPersistentStoreDescription+Metadata.swift in Sources */,
 				02FE153F1E80384A00FF077C /* PersistentContainer+Migration.swift in Sources */,
+				DD75716823DD7DBE00E825EC /* Sequence+Extension.swift in Sources */,
 				02FE15481E80384A00FF077C /* LogMessage.swift in Sources */,
 				02FE15421E80384A00FF077C /* ModelVersionOrder.swift in Sources */,
+				DD75716423DD7DBE00E825EC /* PersistentCloudKitContainer.swift in Sources */,
 				02FE15471E80384A00FF077C /* MigrationDelegate.swift in Sources */,
 				02FE15491E80384A00FF077C /* Helpers.swift in Sources */,
 				02FE15451E80384A00FF077C /* ModelVersionEdge.swift in Sources */,
@@ -794,8 +808,10 @@
 				02FE15631E80385C00FF077C /* Graph.swift in Sources */,
 				02FE155A1E80385C00FF077C /* NSPersistentStoreDescription+Metadata.swift in Sources */,
 				02FE154C1E80385600FF077C /* PersistentContainer+Migration.swift in Sources */,
+				DD75716A23DD7DBE00E825EC /* Sequence+Extension.swift in Sources */,
 				02FE15611E80385C00FF077C /* LogMessage.swift in Sources */,
 				02FE155B1E80385C00FF077C /* ModelVersionOrder.swift in Sources */,
+				DD75716623DD7DBE00E825EC /* PersistentCloudKitContainer.swift in Sources */,
 				02FE15601E80385C00FF077C /* MigrationDelegate.swift in Sources */,
 				02FE15621E80385C00FF077C /* Helpers.swift in Sources */,
 				02FE155E1E80385C00FF077C /* ModelVersionEdge.swift in Sources */,
@@ -813,8 +829,10 @@
 				02FE156E1E80385D00FF077C /* Graph.swift in Sources */,
 				02FE15651E80385D00FF077C /* NSPersistentStoreDescription+Metadata.swift in Sources */,
 				02FE154D1E80385700FF077C /* PersistentContainer+Migration.swift in Sources */,
+				DD75716B23DD7DBE00E825EC /* Sequence+Extension.swift in Sources */,
 				02FE156C1E80385D00FF077C /* LogMessage.swift in Sources */,
 				02FE15661E80385D00FF077C /* ModelVersionOrder.swift in Sources */,
+				DD75716723DD7DBE00E825EC /* PersistentCloudKitContainer.swift in Sources */,
 				02FE156B1E80385D00FF077C /* MigrationDelegate.swift in Sources */,
 				02FE156D1E80385D00FF077C /* Helpers.swift in Sources */,
 				02FE15691E80385D00FF077C /* ModelVersionEdge.swift in Sources */,
@@ -832,8 +850,10 @@
 				02FE15581E80385B00FF077C /* Graph.swift in Sources */,
 				02FE154F1E80385B00FF077C /* NSPersistentStoreDescription+Metadata.swift in Sources */,
 				02FE154B1E80385500FF077C /* PersistentContainer+Migration.swift in Sources */,
+				DD75716923DD7DBE00E825EC /* Sequence+Extension.swift in Sources */,
 				02FE15561E80385B00FF077C /* LogMessage.swift in Sources */,
 				02FE15501E80385B00FF077C /* ModelVersionOrder.swift in Sources */,
+				DD75716523DD7DBE00E825EC /* PersistentCloudKitContainer.swift in Sources */,
 				02FE15551E80385B00FF077C /* MigrationDelegate.swift in Sources */,
 				02FE15571E80385B00FF077C /* Helpers.swift in Sources */,
 				02FE15531E80385B00FF077C /* ModelVersionEdge.swift in Sources */,

--- a/TMLPersistentContainer.xcodeproj/project.pbxproj
+++ b/TMLPersistentContainer.xcodeproj/project.pbxproj
@@ -611,7 +611,6 @@
 					};
 					52D6D9851BEFF229002C0205 = {
 						CreatedOnToolsVersion = 7.1;
-						DevelopmentTeam = D243YH28Y6;
 						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
@@ -1144,7 +1143,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = D243YH28Y6;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Configs/TMLPersistentContainerTests.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.TMLPersistentContainer.TMLPersistentContainer-iOS-Tests";
@@ -1160,7 +1159,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = D243YH28Y6;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Configs/TMLPersistentContainerTests.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.TMLPersistentContainer.TMLPersistentContainer-iOS-Tests";

--- a/TMLPersistentContainer.xcodeproj/project.pbxproj
+++ b/TMLPersistentContainer.xcodeproj/project.pbxproj
@@ -145,6 +145,9 @@
 		DD75716923DD7DBE00E825EC /* Sequence+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD75716323DD7DBE00E825EC /* Sequence+Extension.swift */; };
 		DD75716A23DD7DBE00E825EC /* Sequence+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD75716323DD7DBE00E825EC /* Sequence+Extension.swift */; };
 		DD75716B23DD7DBE00E825EC /* Sequence+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD75716323DD7DBE00E825EC /* Sequence+Extension.swift */; };
+		DD75716D23DD811800E825EC /* TestSequence+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD75716C23DD811800E825EC /* TestSequence+Extension.swift */; };
+		DD75716E23DD812000E825EC /* TestSequence+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD75716C23DD811800E825EC /* TestSequence+Extension.swift */; };
+		DD75716F23DD812100E825EC /* TestSequence+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD75716C23DD811800E825EC /* TestSequence+Extension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -244,6 +247,7 @@
 		DD75028D1C690C7A006590AF /* TMLPersistentContainer-tvOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "TMLPersistentContainer-tvOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD75716223DD7DBE00E825EC /* PersistentCloudKitContainer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PersistentCloudKitContainer.swift; path = Sources/PersistentCloudKitContainer.swift; sourceTree = "<group>"; };
 		DD75716323DD7DBE00E825EC /* Sequence+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Sequence+Extension.swift"; path = "Sources/Sequence+Extension.swift"; sourceTree = "<group>"; };
+		DD75716C23DD811800E825EC /* TestSequence+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "TestSequence+Extension.swift"; path = "Tests/TMLPersistentContainerTests/TestSequence+Extension.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -346,6 +350,7 @@
 				02FE158C1E80394300FF077C /* TestCreateDelete.swift */,
 				02FE158E1E80394300FF077C /* TestCase.swift */,
 				02FE158F1E80394300FF077C /* TestBugs.swift */,
+				DD75716C23DD811800E825EC /* TestSequence+Extension.swift */,
 				02FE15901E80394300FF077C /* SimpleModel.swift */,
 				02FE15911E80394300FF077C /* MultiConfigModel.swift */,
 				02FE15921E80394300FF077C /* ModelNames.swift */,
@@ -795,6 +800,7 @@
 				02FE15951E80394300FF077C /* TestSimpleMigrate.swift in Sources */,
 				02FE15C21E80394300FF077C /* TestLogging.swift in Sources */,
 				02FE159E1E80394300FF077C /* TestModelVersionOrder.swift in Sources */,
+				DD75716D23DD811800E825EC /* TestSequence+Extension.swift in Sources */,
 				02FE15A71E80394300FF077C /* TestModel_Simple_Mapping12.xcmappingmodel in Sources */,
 				02FE15D71E80394300FF077C /* MultiConfigModel.swift in Sources */,
 			);
@@ -887,6 +893,7 @@
 				02FE15961E80394300FF077C /* TestSimpleMigrate.swift in Sources */,
 				02FE15C31E80394300FF077C /* TestLogging.swift in Sources */,
 				02FE159F1E80394300FF077C /* TestModelVersionOrder.swift in Sources */,
+				DD75716E23DD812000E825EC /* TestSequence+Extension.swift in Sources */,
 				02FE15A81E80394300FF077C /* TestModel_Simple_Mapping12.xcmappingmodel in Sources */,
 				02FE15D81E80394300FF077C /* MultiConfigModel.swift in Sources */,
 			);
@@ -916,6 +923,7 @@
 				02FE15971E80394300FF077C /* TestSimpleMigrate.swift in Sources */,
 				02FE15C41E80394300FF077C /* TestLogging.swift in Sources */,
 				02FE15A01E80394300FF077C /* TestModelVersionOrder.swift in Sources */,
+				DD75716F23DD812100E825EC /* TestSequence+Extension.swift in Sources */,
 				02FE15A91E80394300FF077C /* TestModel_Simple_Mapping12.xcmappingmodel in Sources */,
 				02FE15D91E80394300FF077C /* MultiConfigModel.swift in Sources */,
 			);

--- a/Tests/TMLPersistentContainerTests/Delegates.swift
+++ b/Tests/TMLPersistentContainerTests/Delegates.swift
@@ -86,12 +86,12 @@ class Delegate: MigrationDelegate {
         }
     }
 
-    func persistentContainer(_ container: PersistentContainer,
+    func persistentContainer(_ container: NSPersistentContainer,
                              willConsiderStore: NSPersistentStoreDescription) {
         checkCall(.willConsider)
     }
 
-    func persistentContainer(_ container: PersistentContainer,
+    func persistentContainer(_ container: NSPersistentContainer,
                              willMigrateStore: NSPersistentStoreDescription,
                              sourceModelVersion: String,
                              destinationModelVersion: String,
@@ -99,13 +99,13 @@ class Delegate: MigrationDelegate {
         checkCall(.willMigrate(sourceModelVersion, destinationModelVersion, totalSteps))
     }
 
-    func persistentContainer(_ container: PersistentContainer,
+    func persistentContainer(_ container: NSPersistentContainer,
                              willNotMigrateStore: NSPersistentStoreDescription,
                              storeExists: Bool) {
         checkCall(.willNotMigrate(storeExists))
     }
 
-    func persistentContainer(_ container: PersistentContainer,
+    func persistentContainer(_ container: NSPersistentContainer,
                              willSingleMigrateStore: NSPersistentStoreDescription,
                              sourceModelVersion: String,
                              destinationModelVersion: String,
@@ -117,12 +117,12 @@ class Delegate: MigrationDelegate {
         checkCall(.willSingleMigrate(sourceModelVersion, destinationModelVersion, usingInferredMapping, stepsRemaining, totalSteps))
     }
 
-    func persistentContainer(_ container: PersistentContainer,
+    func persistentContainer(_ container: NSPersistentContainer,
                              didMigrateStore: NSPersistentStoreDescription) {
         checkCall(.didMigrate)
     }
 
-    func persistentContainer(_ container: PersistentContainer,
+    func persistentContainer(_ container: NSPersistentContainer,
                              didFailToMigrateStore: NSPersistentStoreDescription,
                              error: Error) {
         checkCall(.didFailToMigrate)

--- a/Tests/TMLPersistentContainerTests/TestCase.swift
+++ b/Tests/TMLPersistentContainerTests/TestCase.swift
@@ -24,24 +24,6 @@ open class TestCase: XCTestCase {
         continueAfterFailure = true
     }
     
-    /// Load an NSManagedObjectModel for a particular model[set]
-    private func loadManagedObjectModel(_ file: ModelName) -> NSManagedObjectModel {
-        // Our models are stored in the test bundle so we cannot use Bundle.main to find it, either
-        // directly or indirectly via the 1-arg init version of [NS]PersistentContainer.
-        // This locates the test bundle via the location of this current class's binary.
-        let unitTestBundle = Bundle(for: type(of: self))
-        
-        guard let modelURL = unitTestBundle.url(forResource: file.rawValue, withExtension: "momd") else {
-            fatalError("Couldn't find \(file.rawValue).momd in the bundle")
-        }
-        
-        guard let managedObjectModel = NSManagedObjectModel(contentsOf: modelURL) else {
-            fatalError("\(file.rawValue).momd doesn't seem to be a managed object model")
-        }
-        
-        return managedObjectModel
-    }
-    
     /// Name of the stores on disk
 
     private static let persistentStoreNames = ["TestStore1", "TestStore2"]
@@ -231,5 +213,28 @@ func loggingCallback(msg: LogMessage) {
     print("LOG: \(msg)")
     if let loggingWatcher = loggingWatcher {
         loggingWatcher(msg.body())
+    }
+}
+
+extension XCTestCase {
+    func url(for fileName: String) -> URL? {
+        // Our models are stored in the test bundle so we cannot use Bundle.main to find it, either
+        // directly or indirectly via the 1-arg init version of [NS]PersistentContainer.
+        // This locates the test bundle via the location of this current class's binary.
+        let unitTestBundle = Bundle(for: type(of: self))
+        return unitTestBundle.url(forResource: fileName, withExtension: "momd")
+    }
+    /// Load an NSManagedObjectModel for a particular model[set]
+    func loadManagedObjectModel(_ file: ModelName) -> NSManagedObjectModel {
+
+        guard let modelURL = url(for: file.rawValue) else {
+            fatalError("Couldn't find \(file.rawValue).momd in the bundle")
+        }
+        
+        guard let managedObjectModel = NSManagedObjectModel(contentsOf: modelURL) else {
+            fatalError("\(file.rawValue).momd doesn't seem to be a managed object model")
+        }
+        
+        return managedObjectModel
     }
 }

--- a/Tests/TMLPersistentContainerTests/TestCase.swift
+++ b/Tests/TMLPersistentContainerTests/TestCase.swift
@@ -8,7 +8,7 @@
 import Foundation
 import CoreData
 import XCTest
-import TMLPersistentContainer
+@testable import TMLPersistentContainer
 
 /// Common base class for container tests holding utilities.
 open class TestCase: XCTestCase {

--- a/Tests/TMLPersistentContainerTests/TestSequence+Extension.swift
+++ b/Tests/TMLPersistentContainerTests/TestSequence+Extension.swift
@@ -1,0 +1,27 @@
+//
+//  TestSequence+Extension.swift
+//  
+//
+//  Created by Jonas Reichert on 25.01.20.
+//
+
+import Foundation
+import XCTest
+@testable import TMLPersistentContainer
+
+class TestSequenceExtension: XCTestCase {
+    let bundle1 = MockBundle(mockedURL: nil)
+    let bundle2 = MockBundle(mockedURL: URL())
+}
+
+class MockBundle: BundleProtocol {
+    var mockedURL: URL?
+    
+    init(mockedURL: URL?) {
+        self.mockedURL = mockedURL
+    }
+    
+    func url(forResource name: String?, withExtension ext: String?) -> URL? {
+        return url
+    }
+}

--- a/Tests/TMLPersistentContainerTests/TestSequence+Extension.swift
+++ b/Tests/TMLPersistentContainerTests/TestSequence+Extension.swift
@@ -22,26 +22,47 @@ class TestSequenceExtension: XCTestCase {
     
     func testManagedObjectModelsWithNameNoMomdsWithName() {
         let name = "NoMomdLikeThat.momd"
-        let bundle = MockBundle(mockedURLs: [name: URL(string: name)!])
+        guard let url = URL(string: name) else {
+            XCTFail("can't create URL for \(name) for some reason")
+            return
+        }
+        
+        let bundle = MockBundle(mockedURLs: [name: url])
         XCTAssertEqual([bundle].managedObjectModels(with: name), [])
     }
     
     func testManagedObjectModelsWithNameExtensionEdgeCase() {
         let name = "momd.notAMomd"
-        let bundle = MockBundle(mockedURLs: [name: URL(string: name)!])
+        
+        guard let url = URL(string: name) else {
+            XCTFail("can't create URL for \(name) for some reason")
+            return
+        }
+        
+        let bundle = MockBundle(mockedURLs: [name: url])
         XCTAssertEqual([bundle].managedObjectModels(with: ModelName.TestModel_Simple_1.rawValue), [])
     }
     
     func testManagedObjectModelsWithNameHappy() {
-        let bundle = MockBundle(mockedURLs: [ModelName.TestModel_Simple_1.rawValue: url(for: ModelName.TestModel_Simple_1.rawValue)!])
-        let bundle2 = MockBundle(mockedURLs: [ModelName.TestModel_MultiConfig_1.rawValue: url(for: ModelName.TestModel_MultiConfig_1.rawValue)!])
+        guard let url1 = url(for: ModelName.TestModel_Simple_1.rawValue), let url2 = url(for: ModelName.TestModel_MultiConfig_1.rawValue) else {
+            XCTFail("can't create URL for \(name) for some reason")
+            return
+        }
+        
+        let bundle = MockBundle(mockedURLs: [ModelName.TestModel_Simple_1.rawValue: url1])
+        let bundle2 = MockBundle(mockedURLs: [ModelName.TestModel_MultiConfig_1.rawValue: url2])
         let result = [bundle, bundle2].managedObjectModels(with: ModelName.TestModel_Simple_1.rawValue)
         XCTAssertEqual(result, [loadManagedObjectModel(ModelName.TestModel_Simple_1)])
     }
     
     func testManagedObjectModelsWithNameHappy2() {
-        let bundle = MockBundle(mockedURLs: [ModelName.TestModel_Simple_1.rawValue: url(for: ModelName.TestModel_Simple_1.rawValue)!])
-        let bundle2 = MockBundle(mockedURLs: [ModelName.TestModel_MultiConfig_1.rawValue: url(for: ModelName.TestModel_MultiConfig_1.rawValue)!])
+        guard let url1 = url(for: ModelName.TestModel_Simple_1.rawValue), let url2 = url(for: ModelName.TestModel_MultiConfig_1.rawValue) else {
+            XCTFail("can't create URL for \(name) for some reason")
+            return
+        }
+        
+        let bundle = MockBundle(mockedURLs: [ModelName.TestModel_Simple_1.rawValue: url1])
+        let bundle2 = MockBundle(mockedURLs: [ModelName.TestModel_MultiConfig_1.rawValue: url2])
         
         let result = [bundle, bundle2].managedObjectModels(with: ModelName.TestModel_MultiConfig_1.rawValue)
         XCTAssertEqual(result, [loadManagedObjectModel(ModelName.TestModel_MultiConfig_1)])

--- a/Tests/TMLPersistentContainerTests/TestSequence+Extension.swift
+++ b/Tests/TMLPersistentContainerTests/TestSequence+Extension.swift
@@ -10,18 +10,56 @@ import XCTest
 @testable import TMLPersistentContainer
 
 class TestSequenceExtension: XCTestCase {
-    let bundle1 = MockBundle(mockedURL: nil)
-    let bundle2 = MockBundle(mockedURL: URL())
+    
+    func testManagedObjectModelsWithNameEmpty() {
+        XCTAssertEqual([Bundle]().managedObjectModels(with: ModelName.TestModel_Simple_1.rawValue), [])
+    }
+    
+    func testManagedObjectModelsWithNameNoMomds() {
+        let bundle = MockBundle(mockedURLs: [:])
+        XCTAssertEqual([bundle].managedObjectModels(with: ModelName.TestModel_Simple_1.rawValue), [])
+    }
+    
+    func testManagedObjectModelsWithNameNoMomdsWithName() {
+        let name = "NoMomdLikeThat.momd"
+        let bundle = MockBundle(mockedURLs: [name: URL(string: name)!])
+        XCTAssertEqual([bundle].managedObjectModels(with: name), [])
+    }
+    
+    func testManagedObjectModelsWithNameExtensionEdgeCase() {
+        let name = "momd.notAMomd"
+        let bundle = MockBundle(mockedURLs: [name: URL(string: name)!])
+        XCTAssertEqual([bundle].managedObjectModels(with: ModelName.TestModel_Simple_1.rawValue), [])
+    }
+    
+    func testManagedObjectModelsWithNameHappy() {
+        let bundle = MockBundle(mockedURLs: [ModelName.TestModel_Simple_1.rawValue: url(for: ModelName.TestModel_Simple_1.rawValue)!])
+        let bundle2 = MockBundle(mockedURLs: [ModelName.TestModel_MultiConfig_1.rawValue: url(for: ModelName.TestModel_MultiConfig_1.rawValue)!])
+        let result = [bundle, bundle2].managedObjectModels(with: ModelName.TestModel_Simple_1.rawValue)
+        XCTAssertEqual(result, [loadManagedObjectModel(ModelName.TestModel_Simple_1)])
+    }
+    
+    func testManagedObjectModelsWithNameHappy2() {
+        let bundle = MockBundle(mockedURLs: [ModelName.TestModel_Simple_1.rawValue: url(for: ModelName.TestModel_Simple_1.rawValue)!])
+        let bundle2 = MockBundle(mockedURLs: [ModelName.TestModel_MultiConfig_1.rawValue: url(for: ModelName.TestModel_MultiConfig_1.rawValue)!])
+        
+        let result = [bundle, bundle2].managedObjectModels(with: ModelName.TestModel_MultiConfig_1.rawValue)
+        XCTAssertEqual(result, [loadManagedObjectModel(ModelName.TestModel_MultiConfig_1)])
+    }
 }
 
-class MockBundle: BundleProtocol {
-    var mockedURL: URL?
+struct MockBundle: BundleProtocol, Equatable {
+    var mockedURLs = [String: URL]()
     
-    init(mockedURL: URL?) {
-        self.mockedURL = mockedURL
+    init(mockedURLs: [String: URL]) {
+        self.mockedURLs = mockedURLs
     }
     
     func url(forResource name: String?, withExtension ext: String?) -> URL? {
-        return url
+        guard let name = name else {
+            return nil
+        }
+        
+        return mockedURLs[name]
     }
 }


### PR DESCRIPTION
This is a quick and naive `NSPersistentCloudKitContainer` adoption by basically cloning the existing `PersistentContainer` class and replacing the super class to `NSPersistentCloudKitContainer`. 

This will fulfill the drop-in requirement but looks pretty ugly right now because of code duplication in the two PersistentContainer class which could not easily be solved since protocol extensions do not support overriding. Maybe with some refactoring this could look a bit nicer

Another approach could be to create a wrapper around the underlying `NSPersistent*Container`. The wrapper could be initialized by injecting the `NSPersistent*Container` or a configuration POSO. The drop-in requirement could still be fulfilled by defining a protocol around NSPersistentContainer interface and adopting it in the wrapper class by routing to the wrapped `NSPersistent*Container`. 